### PR TITLE
Increase css specificity to target only inline image

### DIFF
--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -1,7 +1,7 @@
 @charset "utf-8";
 @namespace epub "http://www.idpf.org/2007/ops";
 
-img{
+#chapter-4 img{
 	max-height: 1em;
 	vertical-align: middle;
 }


### PR DESCRIPTION
the local.css img rule inadvertently affects the title page image on the single-page online view